### PR TITLE
Implement modal dismissal via back button

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -92,7 +92,12 @@ export default function App() {
         keyExtractor={item => item.id}
         renderItem={renderItem}
       />
-      <Modal visible={!!nfcStatus} transparent animationType="fade">
+      <Modal
+        visible={!!nfcStatus}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setNfcStatus(null)}
+      >
         <View style={styles.modalContainer}>
           <View style={styles.modalContent}>
             {nfcStatus === 'writing' && <ActivityIndicator size="large" />}


### PR DESCRIPTION
## Summary
- ensure Android back button dismisses NFC modal by setting `onRequestClose`

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845edeb5b88832bb0fb63fe960d5935