### PR TITLE
Fix NFC write after last update

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -73,6 +73,8 @@ export default function App() {
     setNfcMessage('Hold an NFC tag near your device');
 
     try {
+      // ensure no ongoing scan events interfere with the write flow
+      await NfcManager.unregisterTagEvent().catch(() => {});
       await NfcManager.requestTechnology(NfcTech.Ndef);
 
       setNfcStatus('writing');


### PR DESCRIPTION
## Summary
- ensure existing tag event listeners are removed before entering write mode

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d01962bc8832b9fbcb5570fc5ea03