### PR TITLE
Add NFC permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+  <uses-permission android:name="android.permission.NFC"/>
+  <uses-feature android:name="android.hardware.nfc" android:required="false"/>
   <queries>
     <intent>
       <action android:name="android.intent.action.VIEW"/>

--- a/ios/FabaR0x/FabaR0x.entitlements
+++ b/ios/FabaR0x/FabaR0x.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict/>
+  <dict>
+    <key>com.apple.developer.nfc.readersession.formats</key>
+    <array>
+      <string>NDEF</string>
+    </array>
+  </dict>
 </plist>

--- a/ios/FabaR0x/Info.plist
+++ b/ios/FabaR0x/Info.plist
@@ -81,5 +81,7 @@
     <string>Automatic</string>
     <key>UIViewControllerBasedStatusBarAppearance</key>
     <false/>
+    <key>NFCReaderUsageDescription</key>
+    <string>Use NFC to select stories</string>
   </dict>
 </plist>


### PR DESCRIPTION
## Summary
- allow NFC hardware in Android
- configure Info.plist and entitlements for NFC read sessions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d032932e8832b8a076cc162b85bbc